### PR TITLE
force wx version 2.8 for compatibility

### DIFF
--- a/PirateScope
+++ b/PirateScope
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import wxversion
+wxversion.select('2.8')
 import wx
 from wx.lib import plot
 from wx.lib.wordwrap import wordwrap


### PR DESCRIPTION
This is required on systems that have wxgtk-3.0 installed, otherwise it throws a

```
/usr/lib/python2.7/site-packages/wx-3.0-gtk2/wx/_core.py:16629: UserWarning: wxPython/wxWidgets release number mismatch
warnings.warn("wxPython/wxWidgets release number mismatch")
```

warnings and also breaks later on while starting up.
